### PR TITLE
fix: update depracated getWithDefault from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ let server = Bun.serve({
       request
       ->Request.headers
       ->Headers.get("x-user-name")
-      ->Option.getWithDefault("Unknown user")
+      ->Option.getOr("Unknown user")
 
     Response.make(`Hello ${userName}!`, ~options={status: 200})
   },


### PR DESCRIPTION
Hi, `getWithDefault` is now deprecated. It be better to update the default example to use the new `getOr`.