### PR TITLE
Fix typo in SQL `values` raw JS function

### DIFF
--- a/.changeset/cozy-teams-play.md
+++ b/.changeset/cozy-teams-play.md
@@ -1,0 +1,5 @@
+---
+"rescript-bun": patch
+---
+
+Fix typo in SQL `values` raw JS function

--- a/src/SQL.res
+++ b/src/SQL.res
@@ -51,7 +51,7 @@ let object: (t, {..}, array<string>) => SQLQuery.t<param> = %raw(`
 
 let values: (t, array<'a>) => SQLQuery.t<param> = %raw(`
   function(t, values) {
-    return t(arr)
+    return t(values)
   }
 `)
 


### PR DESCRIPTION
Currently you get: 

```
ReferenceError: arr is not defined
      at Module.values ...
```